### PR TITLE
Adding meta log display

### DIFF
--- a/ai-logger.php
+++ b/ai-logger.php
@@ -23,6 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+define( 'AI_LOGGER_PATH', __DIR__ );
+
 // Check if Composer is installed.
 if ( ! file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	\add_action(

--- a/ai-logger.php
+++ b/ai-logger.php
@@ -54,3 +54,8 @@ if ( ! class_exists( 'AI_Logger\AI_Logger' ) ) {
 }
 
 AI_Logger::instance();
+
+// wp-cli command.
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	\WP_CLI::add_command( 'ai-logger', __NAMESPACE__ . '\CLI' );
+}

--- a/inc/class-cli.php
+++ b/inc/class-cli.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * CLI class file.
+ *
+ * @package AI_Logger
+ */
+
+namespace AI_Logger;
+
+use AI_Logger\Handler\Post_Handler;
+use Psr\Log\LogLevel;
+use WP_CLI;
+
+// phpcs:disable WordPressVIPMinimum.Classes.RestrictedExtendClasses.wp_cli
+
+/**
+ * AI_Logger CLI Command
+ *
+ * Cannot extend `WPCOM_VIP_CLI_Command` since this plugin can run
+ * outside the context of a VIP site.
+ */
+class CLI extends \WP_CLI_Command {
+	/**
+	 * Display the log for a post.
+	 *
+	 * Default meta key is 'log'.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <object_type>
+	 * : Object type (post/term).
+	 *
+	 * <object_id>
+	 * : Object ID.
+	 *
+	 * @synopsis <object_type> <object_id> [--meta_key=<value>]
+	 * @param array $args Arguments for the command.
+	 * @param array $assoc_args Associated flags for the command.
+	 */
+	public function display( $args, $assoc_args ) {
+		list ( $object_type, $object_id ) = $args;
+
+		$assoc_args = \wp_parse_args(
+			$assoc_args,
+			[
+				'meta_key' => 'log',
+			]
+		);
+
+		$logs = \get_metadata( $object_type, $object_id, $assoc_args['meta_key'], false );
+
+		if ( empty( $logs ) ) {
+			WP_CLI::error( 'No logs found.' );
+		}
+
+		WP_CLI\Utils\format_items(
+			'table',
+			array_map(
+				function( $log ) {
+					return [
+						'level'     => $log[0],
+						'message'   => $log[1],
+						'context'   => $log[2],
+						'timestamp' => date_i18n( 'm/d/Y H:i:s', (int) $log[3] ?? '', false ),
+					];
+				},
+				$logs
+			),
+			[
+				'level',
+				'message',
+				'context',
+				'timestamp',
+			]
+		);
+	}
+
+	/**
+	 * Generate some logs for a object (used for development).
+	 *
+	 * ## OPTIONS
+	 *
+	 * <object_type>
+	 * : Object type (post/term).
+	 *
+	 * <object_id>
+	 * : Object ID.
+	 *
+	 * @synopsis <object_type> <object_id> [--meta_key=<value>] [--count=<value>]
+	 * @param array $args Arguments for the command.
+	 * @param array $assoc_args Associated flags for the command.
+	 */
+	public function generate_for_object( $args, $assoc_args ) {
+		list ( $object_type, $object_id ) = $args;
+
+		$assoc_args = \wp_parse_args(
+			$assoc_args,
+			[
+				'count'    => 20,
+				'meta_key' => 'log',
+			]
+		);
+
+		$meta_key = $assoc_args['meta_key'] ?? '';
+
+		$logger = new Logger( 'Log Generator' );
+
+		if ( 'term' === $object_type ) {
+			WP_CLI::log( 'Generating logs using Term_Meta_Handler' );
+			$logger->add_handler( new Handler\Term_Meta_Handler( $object_id, $meta_key ) );
+		} else {
+			WP_CLI::log( 'Generating logs using Post_Meta_Handler' );
+			$logger->add_handler( new Handler\Post_Meta_Handler( $object_id, $meta_key ) );
+		}
+
+		$levels = [
+			LogLevel::EMERGENCY,
+			LogLevel::ALERT,
+			LogLevel::CRITICAL,
+			LogLevel::ERROR,
+			LogLevel::WARNING,
+			LogLevel::NOTICE,
+			LogLevel::INFO,
+			LogLevel::DEBUG,
+		];
+
+		for ( $i = 0; $i < $assoc_args['count']; $i++ ) {
+			$level = $levels[ array_rand( $levels ) ];
+			$logger->$level(
+				'Example log message: ' . $i,
+				[
+					'example_context' => $i,
+				]
+			);
+		}
+
+		WP_CLI::log( 'Generated ' . $assoc_args['count'] . ' log entries.' );
+	}
+
+	/**
+	 * Generate some logs for the site-wide handler.
+	 *
+	 * @synopsis [--count=<value>]
+	 * @param array $args Arguments for the command.
+	 * @param array $assoc_args Associated flags for the command.
+	 */
+	public function generate_for_blog( $args, $assoc_args ) {
+		$assoc_args = \wp_parse_args(
+			$assoc_args,
+			[
+				'count' => 20,
+			]
+		);
+
+		$logger = new Logger( 'Log Generator', [ new Post_Handler() ] );
+
+		$levels = [
+			LogLevel::EMERGENCY,
+			LogLevel::ALERT,
+			LogLevel::CRITICAL,
+			LogLevel::ERROR,
+			LogLevel::WARNING,
+			LogLevel::NOTICE,
+			LogLevel::INFO,
+			LogLevel::DEBUG,
+		];
+
+		for ( $i = 0; $i < $assoc_args['count']; $i++ ) {
+			$level = $levels[ array_rand( $levels ) ];
+			$logger->$level(
+				'Example log message: ' . $i,
+				[
+					'example_context' => $i,
+				]
+			);
+		}
+
+		WP_CLI::log( 'Generated ' . $assoc_args['count'] . ' log entries.' );
+	}
+}

--- a/inc/class-cli.php
+++ b/inc/class-cli.php
@@ -127,7 +127,7 @@ class CLI extends \WP_CLI_Command {
 		for ( $i = 0; $i < $assoc_args['count']; $i++ ) {
 			$level = $levels[ array_rand( $levels ) ];
 			$logger->$level(
-				'Example log message: ' . $i,
+				'Example log message: ' . ( $i + 1 ),
 				[
 					'example_context' => $i,
 				]
@@ -168,7 +168,7 @@ class CLI extends \WP_CLI_Command {
 		for ( $i = 0; $i < $assoc_args['count']; $i++ ) {
 			$level = $levels[ array_rand( $levels ) ];
 			$logger->$level(
-				'Example log message: ' . $i,
+				'Example log message: ' . ( $i + 1 ),
 				[
 					'example_context' => $i,
 				]

--- a/inc/meta-box/class-meta-box.php
+++ b/inc/meta-box/class-meta-box.php
@@ -14,13 +14,6 @@ namespace AI_Logger\Meta_Box;
  */
 abstract class Meta_Box {
 	/**
-	 * Object ID.
-	 *
-	 * @var int
-	 */
-	protected $object_id;
-
-	/**
 	 * Meta key for the logs.
 	 *
 	 * @var string
@@ -37,14 +30,14 @@ abstract class Meta_Box {
 	/**
 	 * Constructor
 	 *
-	 * @param int    $object_id Object ID.
 	 * @param string $meta_key Meta key for logs.
 	 * @param string $title Title for the meta box.
 	 */
-	public function __construct( int $object_id, string $meta_key, string $title ) {
-		$this->object_id = $object_id;
-		$this->meta_key  = $meta_key;
-		$this->title     = $title;
+	public function __construct( string $meta_key, string $title ) {
+		$this->meta_key = $meta_key;
+		$this->title    = $title;
+
+		$this->register_meta_box();
 	}
 
 	/**
@@ -61,14 +54,32 @@ abstract class Meta_Box {
 
 	/**
 	 * Render the meta box.
+	 *
+	 * @param mixed $object Object to render meta box for.
 	 */
-	public function render_meta_box() {
-		$logs = \get_metadata( $this->get_meta_type(), $this->object_id, $this->meta_key, false );
+	public function render_meta_box( $object ) {
+		if ( $object instanceof \WP_Post ) {
+			$object_id = $object->ID;
+		} elseif ( $object instanceof \WP_Term ) {
+			$object_id = $object->term_id;
+		} else {
+			// Bail if unknown.
+			return;
+		}
+
+		$logs = \get_metadata( $this->get_meta_type(), $object_id, $this->meta_key, false );
 
 		if ( empty( $logs ) || ! is_array( $logs ) ) {
 			return;
 		}
 
-		include __DIR__ . '/template-parts/meta-box.php';
+		if ( 'term' === $this->get_meta_type() ) {
+			printf(
+				'<h4>%s</h4>',
+				esc_html( $this->title )
+			);
+		}
+
+		include AI_LOGGER_PATH . '/template-parts/meta-box.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant
 	}
 }

--- a/inc/meta-box/class-meta-box.php
+++ b/inc/meta-box/class-meta-box.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Meta_Box class file.
+ *
+ * @package AI_Logger
+ */
+
+namespace AI_Logger\Meta_Box;
+
+/**
+ * Logger Meta Box
+ *
+ * Expose stored logs to the front-end.
+ */
+abstract class Meta_Box {
+	/**
+	 * Object ID.
+	 *
+	 * @var int
+	 */
+	protected $object_id;
+
+	/**
+	 * Meta key for the logs.
+	 *
+	 * @var string
+	 */
+	protected $meta_key;
+
+	/**
+	 * Meta box title.
+	 *
+	 * @var string
+	 */
+	protected $title;
+
+	/**
+	 * Constructor
+	 *
+	 * @param int    $object_id Object ID.
+	 * @param string $meta_key Meta key for logs.
+	 * @param string $title Title for the meta box.
+	 */
+	public function __construct( int $object_id, string $meta_key, string $title ) {
+		$this->object_id = $object_id;
+		$this->meta_key  = $meta_key;
+		$this->title     = $title;
+	}
+
+	/**
+	 * Meta type to retrieve the logs for.
+	 *
+	 * @return string
+	 */
+	abstract public function get_meta_type(): string;
+
+	/**
+	 * Method to retrieve the meta box for display.
+	 */
+	abstract public function register_meta_box();
+
+	/**
+	 * Render the meta box.
+	 */
+	public function render_meta_box() {
+		$logs = \get_metadata( $this->get_meta_type(), $this->object_id, $this->meta_key, false );
+
+		if ( empty( $logs ) || ! is_array( $logs ) ) {
+			return;
+		}
+
+		include __DIR__ . '/template-parts/meta-box.php';
+	}
+}

--- a/inc/meta-box/class-post-meta-box.php
+++ b/inc/meta-box/class-post-meta-box.php
@@ -31,10 +31,10 @@ class Post_Meta_Box extends Meta_Box {
 	 * Register the log meta box.
 	 *
 	 * @param string   $post_type Post type.
-	 * @param \WP_post $post Post object.
+	 * @param \WP_Post $post Post object.
 	 */
-	public function register_meta_boxes( $post_type, $post ) {
-		$meta = \get_post_meta( $this->object_id, $this->meta_key, false );
+	public function add_meta_boxes( $post_type, $post ) {
+		$meta = \get_post_meta( $post->ID, $this->meta_key, false );
 
 		if ( empty( $meta ) || ! is_array( $meta ) ) {
 			return;

--- a/inc/meta-box/class-post-meta-box.php
+++ b/inc/meta-box/class-post-meta-box.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Post_Meta_Box class file.
+ *
+ * @package AI_Logger
+ */
+
+namespace AI_Logger\Meta_Box;
+
+/**
+ * Post Log Meta Box
+ */
+class Post_Meta_Box extends Meta_Box {
+	/**
+	 * Meta type to retrieve the logs for.
+	 *
+	 * @return string
+	 */
+	public function get_meta_type(): string {
+		return 'post';
+	}
+
+	/**
+	 * Method to retrieve the meta box for display.
+	 */
+	public function register_meta_box() {
+		\add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ], 10, 2 );
+	}
+
+	/**
+	 * Register the log meta box.
+	 *
+	 * @param string   $post_type Post type.
+	 * @param \WP_post $post Post object.
+	 */
+	public function register_meta_boxes( $post_type, $post ) {
+		$meta = \get_post_meta( $this->object_id, $this->meta_key, false );
+
+		if ( empty( $meta ) || ! is_array( $meta ) ) {
+			return;
+		}
+
+		\add_meta_box(
+			'ai-logger-' . $this->meta_key,
+			$this->title,
+			[ $this, 'render_meta_box' ],
+			$post_type,
+			'normal',
+			'low'
+		);
+	}
+}

--- a/inc/meta-box/class-term-meta-box.php
+++ b/inc/meta-box/class-term-meta-box.php
@@ -12,6 +12,25 @@ namespace AI_Logger\Meta_Box;
  */
 class Term_Meta_Box extends Meta_Box {
 	/**
+	 * Taxonomies to enable it for.
+	 *
+	 * @var string[]
+	 */
+	protected $taxonomies = [];
+
+	/**
+	 * Constructor
+	 *
+	 * @param string $meta_key Meta key for logs.
+	 * @param string $title Title for the meta box.
+	 * @param array  $taxonomies Taxonomies to use.
+	 */
+	public function __construct( string $meta_key, string $title, array $taxonomies ) {
+		$this->taxonomies = $taxonomies;
+		parent::__construct( $meta_key, $title );
+	}
+
+	/**
 	 * Meta type to retrieve the logs for.
 	 *
 	 * @return string
@@ -24,9 +43,8 @@ class Term_Meta_Box extends Meta_Box {
 	 * Method to retrieve the meta box for display.
 	 */
 	public function register_meta_box() {
-		$term = \get_term( $this->object_id );
-		if ( $term instanceof \WP_Term ) {
-			\add_action( "{$term->taxonomy}_edit_form", [ $this, 'render_meta_box' ], 99 );
+		foreach ( $this->taxonomies as $taxonomy ) {
+			\add_action( "{$taxonomy}_edit_form", [ $this, 'render_meta_box' ], 99 );
 		}
 	}
 }

--- a/inc/meta-box/class-term-meta-box.php
+++ b/inc/meta-box/class-term-meta-box.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Term_Meta_Box class file.
+ *
+ * @package AI_Logger
+ */
+
+namespace AI_Logger\Meta_Box;
+
+/**
+ * Term Log Meta Box
+ */
+class Term_Meta_Box extends Meta_Box {
+	/**
+	 * Meta type to retrieve the logs for.
+	 *
+	 * @return string
+	 */
+	public function get_meta_type(): string {
+		return 'term';
+	}
+
+	/**
+	 * Method to retrieve the meta box for display.
+	 */
+	public function register_meta_box() {
+		$term = \get_term( $this->object_id );
+		if ( $term instanceof \WP_Term ) {
+			\add_action( "{$term->taxonomy}_edit_form", [ $this, 'render_meta_box' ], 99 );
+		}
+	}
+}

--- a/template-parts/meta-box.php
+++ b/template-parts/meta-box.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Meta Box display.
+ *
+ * @package AI_Logger
+ */
+
+namespace AI_Logger;
+
+use Psr\Log\LogLevel;
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+
+// $logs comes from the parent function.
+if ( empty( $logs ) ) {
+	return;
+}
+
+$ai_logger_timestamp_format = 'm/d/Y H:i:s';
+?>
+
+<table class="widefat fixed meta-box-logs" width="100%">
+	<thead>
+		<tr>
+			<th align="left"><?php esc_html_e( 'Level', 'ai-logger' ); ?></th>
+			<th align="left"><?php esc_html_e( 'Message', 'ai-logger' ); ?></th>
+			<th align="left"><?php esc_html_e( 'Context', 'ai-logger' ); ?></th>
+			<th align="left"><?php esc_html_e( 'Timestamp', 'ai-logger' ); ?></th>
+		</tr>
+	</thead>
+	<tbody>
+		<?php foreach ( $logs as $log ) : ?>
+			<tr
+				<?php if ( in_array( $log[0], [ LogLevel::EMERGENCY, LogLevel::CRITICAL ], true ) ) : ?>
+					bgcolor="red"
+				<?php elseif ( LogLevel::ALERT === $log[0] ) : ?>
+					bgcolor="orange"
+				<?php endif; ?>
+			>
+				<td><?php echo esc_html( $log[0] ?? '' ); ?></td>
+				<td><?php echo esc_html( $log[1] ?? '' ); ?></td>
+				<td>
+					<?php
+					if ( ! empty( $log[2] ) ) {
+						if ( is_array( $log[2] ) ) {
+							printf( '<code>%s</code>', wp_json_encode( $log[2] ) );
+						} else {
+							echo esc_html( $log[2] );
+						}
+					}
+					?>
+				</td>
+				<td>
+					<?php echo esc_html( date_i18n( $ai_logger_timestamp_format, (int) $log[3] ?? '', false ) ); ?>
+				</td>
+			</tr>
+		<?php endforeach; ?>
+	</tbody>
+</table>


### PR DESCRIPTION
- Adds an easy-to-use display class for post/term logs that can be display in a meta box on the post/term or in the CLI.
- Adds a helpful command to generate logs for a site/post/term.

Resolves #20 