### PR TITLE
Prefix Logger to AI_Logger

### DIFF
--- a/static/js/logger-insert.js
+++ b/static/js/logger-insert.js
@@ -1,7 +1,7 @@
 
 window.aiLogger = window.aiLogger || [];
 
-class Logger {
+class AI_Logger {
   /**
    * Constructor.
    *
@@ -39,4 +39,4 @@ class Logger {
   }
 }
 
-window.aiLogger = new Logger(...window.aiLogger || []);
+window.aiLogger = new AI_Logger(...window.aiLogger || []);


### PR DESCRIPTION
Prevent a conflict on the front-end: `Uncaught SyntaxError: Identifier 'Logger' has already been declared`