### PR TITLE
Store the user agent on requests

### DIFF
--- a/inc/class-ai-logger-js.php
+++ b/inc/class-ai-logger-js.php
@@ -70,8 +70,10 @@ class AI_Logger_JS {
 		}
 
 		// Setup some default arguments.
-		$level           = $args['level'] ?? 'info';
-		$args['context'] = $args['context'] ?? 'front-end';
+		$level = $args['level'] ?? 'info';
+
+		$args['context']   = $args['context'] ?? 'front-end';
+		$args['useragent'] = $args['useragent'] ?? sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ?? '' );
 
 		$logger = ai_logger();
 

--- a/inc/handler/class-post-handler.php
+++ b/inc/handler/class-post-handler.php
@@ -97,7 +97,9 @@ class Post_Handler extends AbstractProcessingHandler implements Handler_Interfac
 		$user = wp_get_current_user();
 
 		// Capture the stack trace.
-		$record['extra']['backtrace'] = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		if ( empty( $log['context'] ) || 'front-end' !== $log['context'] ) {
+			$record['extra']['backtrace'] = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		}
 
 		if ( $user ) {
 			$record['extra']['user'] = [


### PR DESCRIPTION
- Store the user agent in the context for debugging.
- Prevent the backtrace from being generated for front-end requests.