### PR TITLE
Allow filtering by context/log level in admin

### DIFF
--- a/inc/class-cli.php
+++ b/inc/class-cli.php
@@ -7,7 +7,9 @@
 
 namespace AI_Logger;
 
+use AI_Logger\Handler\Post_Handler;
 use Monolog\Logger;
+use Psr\Log\LogLevel;
 use WP_CLI;
 
 // phpcs:disable WordPressVIPMinimum.Classes.RestrictedExtendClasses.wp_cli
@@ -144,19 +146,25 @@ class CLI extends \WP_CLI_Command {
 	/**
 	 * Generate some logs for the site-wide handler.
 	 *
-	 * @synopsis [--count=<value>]
+	 * @synopsis [--count=<value>] [--log-context=<value>]
+	 *
 	 * @param array $args Arguments for the command.
 	 * @param array $assoc_args Associated flags for the command.
 	 */
-	public function generate_for_blog( $args, $assoc_args ) {
+	public function generate( $args, $assoc_args ) {
 		$assoc_args = \wp_parse_args(
 			$assoc_args,
 			[
-				'count' => 20,
+				'count'       => 20,
+				'log-context' => 'wp-cli generator',
 			]
 		);
 
-		$logger = AI_Logger::instance()->logger();
+		$logger = ai_logger()->with_handlers(
+			[
+				new Post_Handler(),
+			]
+		);
 
 		$levels = [
 			LogLevel::EMERGENCY,
@@ -174,7 +182,7 @@ class CLI extends \WP_CLI_Command {
 			$logger->$level(
 				'Example log message: ' . ( $i + 1 ),
 				[
-					'context'         => 'wp-cli generator',
+					'context'         => $assoc_args['log-context'],
 					'example_context' => $i,
 				]
 			);

--- a/inc/class-data-structures.php
+++ b/inc/class-data-structures.php
@@ -40,6 +40,7 @@ class Data_Structures {
 		\add_action( 'init', [ $this, 'create_taxonomy' ] );
 		\add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ] );
 		\add_action( 'restrict_manage_posts', [ $this, 'add_taxonomy_filters' ] );
+
 	}
 
 	/**
@@ -215,7 +216,13 @@ class Data_Structures {
 
 		wp_dropdown_categories(
 			[
-				'show_option_all' => esc_html( "Show All {$taxonomy_obj->label}" ),
+				'show_option_all' => esc_html(
+					sprintf(
+						/* translators: %s: Taxonomy name. */
+						__( 'Show All %s', 'ai-logger' ),
+						$taxonomy_obj->label,
+					),
+				),
 				'taxonomy'        => $taxonomy,
 				'name'            => $taxonomy,
 				'id'              => $taxonomy,

--- a/template-parts/log-display.php
+++ b/template-parts/log-display.php
@@ -44,7 +44,7 @@ function ai_logger_render_table( array $data ) {
 					</table>
 				<?php elseif ( is_scalar( $value ) ) : ?>
 					<pre><?php // phpcs:ignore Squiz.PHP.EmbeddedPhp.ContentBeforeOpen, Squiz.PHP.EmbeddedPhp.ContentAfterOpen
-					if ( wp_startswith( $value, '{' ) || wp_startswith( $value, '[' ) ) {
+					if ( 0 === strpos( $value, '{' ) || 0 === strpos( $value, '[' ) ) {
 						$maybe_json_value = json_decode( $value );
 						if ( ! empty( $maybe_json_value ) ) {
 							$value = wp_json_encode( $maybe_json_value, JSON_PRETTY_PRINT );


### PR DESCRIPTION
<img width="1055" alt="SCR-20221212-fhb" src="https://user-images.githubusercontent.com/346399/207095131-74f180f9-8240-47aa-a9b3-36346185495a.png">

Allow for logs to be drilled down by context and/or log level in admin.

Fixes #74 