### PR TITLE
Support default context for logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 - Dependency bumps.
-- Drops support for PHP 7.4.
+- Drops support for PHP 7.4. Requires 8.0.
 - Adding support for `psr/log` support for v1 through v3.
+- Adds support for logging with default context (`ai_logger()->with_context(...)`).
+- Improves log filtering in admin.
 
 ## 2.2.0
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ ai_logger_to_term( $term_id, 'meta-key' )->info( 'This will log to the <meta-key
 ai_logger_to_qm()->info( 'This will show up in Query Monitor!' );
 ```
 
+### Logging with Default Context
+
+```php
+ai_logger()->with_context( 'example-context' )->info( 'This will log to the example-context.' );
+```
+
+Also supports an array of default log context:
+
+```php
+ai_logger()->with_context(
+	[
+		'context' => 'example-context',
+		'key'     => 'value',
+	]
+)->info( 'This will log to the example-context with key=>value.' );
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ ai_logger()->with_context(
 )->info( 'This will log to the example-context with key=>value.' );
 ```
 
+You can also pass the context to `ai_logger()` directly:
+
+```php
+ai_logger( 'example-context' )->info( 'This will log to the example-context.' );
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed

--- a/ai-logger.php
+++ b/ai-logger.php
@@ -13,7 +13,6 @@
  * Domain Path: /languages/
  *
  * @package AI_Logger
- * @author jaredcobb
  */
 
 use Monolog\Logger;
@@ -48,9 +47,14 @@ require_once __DIR__ . '/inc/bootstrap.php';
 /**
  * Retrieve the core logger instance.
  *
+ * @param array|string|null $context Default context to apply to the logger, optional.
  * @return \AI_Logger\AI_Logger
  */
-function ai_logger(): \AI_Logger\AI_Logger {
+function ai_logger( array|string|null $context = null ): \AI_Logger\AI_Logger {
+	if ( $context ) {
+		return \AI_Logger\AI_Logger::instance()->with_context( $context );
+	}
+
 	return \AI_Logger\AI_Logger::instance();
 }
 

--- a/inc/class-ai-logger.php
+++ b/inc/class-ai-logger.php
@@ -77,7 +77,36 @@ class AI_Logger implements LoggerInterface {
 	 */
 	public function with_handlers( array $handlers ) {
 		$logger = clone $this;
+
 		$logger->logger->setHandlers( $handlers );
+
+		return $logger;
+	}
+
+	/**
+	 * Retrieve a logger instance with default context attached.
+	 *
+	 * @param array|string $context Context to attach to the logger. If a string
+	 *                              is passed, it will be used as the 'context' key
+	 *                              that is stored as a taxonomy term for the log record.
+	 * @return static
+	 */
+	public function with_context( array|string $context ) {
+		if ( is_string( $context ) ) {
+			$context = [ 'context' => $context ];
+		}
+
+		$logger = clone $this;
+
+		$logger->logger->pushProcessor(
+			function ( $record ) use ( $context ) {
+				$record['context'] = array_merge( $context, $record['context'] ?? [] );
+
+				return $record;
+			}
+		);
+
+
 		return $logger;
 	}
 

--- a/tests/test-logger.php
+++ b/tests/test-logger.php
@@ -80,6 +80,56 @@ class Test_Logger extends Test_Case {
 		$this->assertTrue( $_SERVER['__filter_invoked'] );
 		$this->assertInstanceOf( NullHandler::class, $instance->logger()->getHandlers()[0] );
 	}
+
+	public function test_with_context_string() {
+		$handler = new TestHandler();
+
+		$logger = ai_logger()
+			->with_handlers( [ $handler ] )
+			->with_context( 'example-context' );
+
+		$logger->info( 'Test message', [ 'test' => 'value' ] );
+
+		$this->assertTrue(
+			$handler->hasInfo(
+				[
+					'message' => 'Test message',
+					'context' => [
+						'context' => 'example-context',
+						'test'    => 'value'
+					],
+				],
+			)
+		);
+	}
+
+	public function test_with_context() {
+		$handler = new TestHandler();
+
+		$logger = ai_logger()
+			->with_handlers( [ $handler ] )
+			->with_context(
+				[
+					'context' => 'term',
+					'default' => 'value',
+				]
+			);
+
+		$logger->info( 'Test message', [ 'test' => 'value' ] );
+
+		$this->assertTrue(
+			$handler->hasInfo(
+				[
+					'message' => 'Test message',
+					'context' => [
+						'context' => 'term',
+						'default' => 'value',
+						'test'    => 'value'
+					],
+				],
+			)
+		);
+	}
 }
 
 


### PR DESCRIPTION
```php
ai_logger()->with_context( 'example-context' )->info( 'This will log to the example-context.' );
```

Also supports an array of default log context:

```php
ai_logger()->with_context(
	[
		'context' => 'example-context',
		'key'     => 'value',
	]
)->info( 'This will log to the example-context with key=>value.' );
```

Resolves #41