### PR TITLE
Update Logger plugin to version 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a
 CHANGELOG](https://keepachangelog.com/en/1.0.0/).
 
+## 2.4.2 - 2024-06-28
+
+- Fix an incorrectly named variable in the `Post_Handler` class.
+
 ## 2.4.1 - 2024-04-30
 
 - Re-release of 2.4.1.

--- a/inc/handler/class-post-handler.php
+++ b/inc/handler/class-post-handler.php
@@ -98,7 +98,7 @@ class Post_Handler extends AbstractProcessingHandler implements Handler_Interfac
 	 * @param array $record Log Record.
 	 */
 	protected function write( array $record ): void {
-		if ( empty( $log['context'] ) || 'front-end' !== $log['context'] ) {
+		if ( empty( $record['context'] ) || 'front-end' !== $record['context'] ) {
 			// Store the backtrace for only this handler. Not created as a processor
 			// to avoid bloat of backtrace on all log types.
 			$record['extra']['backtrace'] = Backtrace::create()->startingFromFrame(

--- a/logger.php
+++ b/logger.php
@@ -3,11 +3,11 @@
  * Plugin Name: Alley Logger
  * Plugin URI: https://github.com/alleyinteractive/logger
  * Description: A Monolog-based logging tool for WordPress. Supports storing log message in a custom post type or in individual posts and terms.
- * Version: 2.4.1
+ * Version: 2.4.2
  * Author: Alley Interactive
  * Author URI: https://alley.com/
  * Requires at least: 5.9
- * Tested up to: 5.9
+ * Tested up to: 6.5.5
  *
  * Text Domain: ai-logger
  * Domain Path: /languages/


### PR DESCRIPTION
This commit updates the Alley Logger plugin to version 2.4.2. It corrects an incorrectly named variable in the `Post_Handler` class which improves the plugin's overall functionality and reliability. Moreover, the plugin compatibility has been updated, confirming it's tested with WordPress version 6.5.5.

Fixes #122 