### PR TITLE
Fix error in with_processors

### DIFF
--- a/inc/class-ai-logger.php
+++ b/inc/class-ai-logger.php
@@ -98,7 +98,7 @@ class AI_Logger implements LoggerInterface {
 			while ( $logger->logger->popProcessor() ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedWhile
 				// Do nothing.
 			}
-		} catch ( \LogicException $e ) {
+		} catch ( \LogicException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// Do nothing.
 		}
 

--- a/inc/class-ai-logger.php
+++ b/inc/class-ai-logger.php
@@ -93,12 +93,18 @@ class AI_Logger implements LoggerInterface {
 	public function with_processors( array $processors ) {
 		$logger = clone $this;
 
-		// Clear all processors with popProcessor().
-		while ( $logger->logger->popProcessor() ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedWhile
+		try {
+			// Clear all processors with popProcessor().
+			while ( $logger->logger->popProcessor() ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedWhile
+				// Do nothing.
+			}
+		} catch ( \LogicException $e ) {
 			// Do nothing.
 		}
 
-		$logger->logger->pushProcessor( $processors );
+		foreach ( $processors as $processor ) {
+			$logger->logger->pushProcessor( $processor );
+		}
 
 		return $logger;
 	}


### PR DESCRIPTION
This fixes an issue with `with_processors` where Monolog was throwing a `LogicException` when attempting to pop off an empty stack. It also fixes an issue where monolog was throwing an error when attempting to push an array to `pushProcessor` instead of an individual processor class.

Fixes #132 